### PR TITLE
feat: parse property types containing groups

### DIFF
--- a/tests/__fixtures__/operators.cddl
+++ b/tests/__fixtures__/operators.cddl
@@ -33,3 +33,9 @@ group1 = {
 group2 = {
     handle: tstr
 } .and group1
+
+groupedRangeWithOperator = {
+    name: tstr,
+    ? range: (1.0..2.0) .default 1.5,
+    ? nullable: (float .ge 1.0) / null
+}

--- a/tests/__snapshots__/parser.test.ts.snap
+++ b/tests/__snapshots__/parser.test.ts.snap
@@ -2178,6 +2178,87 @@ exports[`parser > can parse operators 1`] = `
     ],
     "Type": "group",
   },
+  {
+    "Comments": [],
+    "IsChoiceAddition": false,
+    "Name": "groupedRangeWithOperator",
+    "Properties": [
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "name",
+        "Occurrence": {
+          "m": 1,
+          "n": 1,
+        },
+        "Type": [
+          "tstr",
+        ],
+      },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "range",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Type": [
+          {
+            "Operator": {
+              "Type": "default",
+              "Value": {
+                "Type": "literal",
+                "Unwrapped": false,
+                "Value": 1.5,
+              },
+            },
+            "Type": {
+              "Type": "range",
+              "Unwrapped": false,
+              "Value": {
+                "Inclusive": true,
+                "Max": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 2,
+                },
+                "Min": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 1,
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "nullable",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Type": [
+          {
+            "Operator": {
+              "Type": "ge",
+              "Value": {
+                "Type": "literal",
+                "Unwrapped": false,
+                "Value": 1,
+              },
+            },
+            "Type": "float",
+          },
+          "null",
+        ],
+      },
+    ],
+    "Type": "group",
+  },
 ]
 `;
 


### PR DESCRIPTION
Update parser to handle the following cases in property type definitions:

```
groupedWithRangeOperator = {
    name: tstr,
    ? rangeWithOperator: (1.0..2.0) .default 1.5, ; range operator in parentheses
    ? nullable: (float .ge 1.0) / null ; property has operator or is another type
}
```