### PR TITLE
fix: handle range definition in parentheses

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -395,9 +395,6 @@ export default class Parser {
                 propertyType.push(props)
             }
 
-            // const postOperator = this.isOperator() ? this.parseOperator() : undefined
-
-
             /**
              * advance comma
              */

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -783,6 +783,10 @@ export default class Parser {
             this.nextToken() // eat `/`
             propertyTypes.push(this.parsePropertyType())
             if (!this.isOperator()) {
+                /**
+                 * If we are not parsing an operator, we need to eat the next token;
+                 * otherwise, the operator will be parsed by the caller
+                 */
                 this.nextToken()
             }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -173,9 +173,11 @@ export default class Parser {
          * parse operator assignments, e.g. `ip4 = (float .ge 0.0) .default 1.0`
          */
         if (closingTokens.length === 1 && this.peekToken.Type === Tokens.DOT) {
+            const propertyType = this.parsePropertyType()
+            const operator = this.isOperator() ? this.parseOperator() : undefined
             const prop: PropertyType = {
-                Type: this.parsePropertyType(),
-                Operator: this.parseOperator()
+                Type: propertyType,
+                ...(operator ? { Operator: operator } : {})
             } as NativeTypeWithOperator
 
             this.nextToken() // eat closing token
@@ -392,6 +394,9 @@ export default class Parser {
             } else {
                 propertyType.push(props)
             }
+
+            // const postOperator = this.isOperator() ? this.parseOperator() : undefined
+
 
             /**
              * advance comma

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -374,7 +374,7 @@ export default class Parser {
              */
             const props = this.parseAssignmentValue()
             const operator = this.isOperator() ? this.parseOperator() : undefined
-            if (!isChoice &&this.curToken.Type === Tokens.SLASH) {
+            if (!isChoice && this.curToken.Type === Tokens.SLASH) {
                 this.nextToken()
                 const nextType = this.parsePropertyType()
                 if (Array.isArray(props)) {
@@ -782,7 +782,9 @@ export default class Parser {
         while (this.curToken.Type === Tokens.SLASH) {
             this.nextToken() // eat `/`
             propertyTypes.push(this.parsePropertyType())
-            this.nextToken()
+            if (!this.isOperator()) {
+                this.nextToken()
+            }
 
             /**
              * ensure we don't go into the next choice, e.g.:

--- a/tests/__fixtures__/operators.cddl
+++ b/tests/__fixtures__/operators.cddl
@@ -38,5 +38,6 @@ groupedRangeWithOperator = {
     name: tstr,
     ? range: (1.0..2.0) .default 1.5,
     ? nullable: (float .ge 1.0) / null,
-    ? rangeOrNull: (0.0...360.0) / null
+    ? rangeOrNull: (0.0...360.0) / null,
+    ? choiceWithPostFixOperator: float / null .default null
 }

--- a/tests/__fixtures__/operators.cddl
+++ b/tests/__fixtures__/operators.cddl
@@ -37,5 +37,6 @@ group2 = {
 groupedRangeWithOperator = {
     name: tstr,
     ? range: (1.0..2.0) .default 1.5,
-    ? nullable: (float .ge 1.0) / null
+    ? nullable: (float .ge 1.0) / null,
+    ? rangeOrNull: (0.0...360.0) / null
 }

--- a/tests/__snapshots__/parser.test.ts.snap
+++ b/tests/__snapshots__/parser.test.ts.snap
@@ -2287,6 +2287,23 @@ exports[`parser > can parse operators 1`] = `
           "null",
         ],
       },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "choiceWithPostFixOperator",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Operator": {
+          "Type": "default",
+          "Value": "null",
+        },
+        "Type": [
+          "float",
+          "null",
+        ],
+      },
     ],
     "Type": "group",
   },

--- a/tests/__snapshots__/parser.test.ts.snap
+++ b/tests/__snapshots__/parser.test.ts.snap
@@ -2256,6 +2256,37 @@ exports[`parser > can parse operators 1`] = `
           "null",
         ],
       },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "rangeOrNull",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Type": [
+          {
+            "Type": {
+              "Type": "range",
+              "Unwrapped": false,
+              "Value": {
+                "Inclusive": false,
+                "Max": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 360,
+                },
+                "Min": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 0,
+                },
+              },
+            },
+          },
+          "null",
+        ],
+      },
     ],
     "Type": "group",
   },


### PR DESCRIPTION
This fix handles constructs like `? propertyName: (0.0...360.0) / null`. It also handles the case where there is an operator that postfixes the choice, like `? choiceWithPostFixOperator: float / null .default null`.