### PR TITLE
feat: handle further edge cases in operators

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -373,7 +373,7 @@ export default class Parser {
              * parse property value
              */
             const props = this.parseAssignmentValue()
-            const operator = this.isOperator() ? this.parseOperator() : undefined
+            let operator = this.isOperator() ? this.parseOperator() : undefined
             if (!isChoice && this.curToken.Type === Tokens.SLASH) {
                 this.nextToken()
                 const nextType = this.parsePropertyType()
@@ -383,8 +383,13 @@ export default class Parser {
                      * of one, e.g. `(float .ge 1.0) / null`
                      */
                     props.push(nextType)
-                    this.nextToken()
+                    if (!this.isOperator()) {
+                        this.nextToken()
+                    }
                 }
+            }
+            if (this.isOperator()) {
+                operator = this.parseOperator()
             }
             if (Array.isArray(props)) {
                 /**
@@ -717,7 +722,7 @@ export default class Parser {
                  * as a grouped range.
                  */
                 this.nextToken()
-                if (this.peekToken.Type === Tokens.DOT) {
+                if (this.isOperator()) {
                     isGroupedRange = true
                 }
             }

--- a/tests/__fixtures__/operators.cddl
+++ b/tests/__fixtures__/operators.cddl
@@ -39,5 +39,7 @@ groupedRangeWithOperator = {
     ? range: (1.0..2.0) .default 1.5,
     ? nullable: (float .ge 1.0) / null,
     ? rangeOrNull: (0.0...360.0) / null,
-    ? choiceWithPostFixOperator: float / null .default null
+    ? choiceWithPostFixOperator: float / null .default null,
+    ? anotherChoice: (0.0...360.0) / null .default null,
+    ? yetAnotherChoice: (float .ge 1.0) / null .default null
 }

--- a/tests/__snapshots__/parser.test.ts.snap
+++ b/tests/__snapshots__/parser.test.ts.snap
@@ -2203,16 +2203,16 @@ exports[`parser > can parse operators 1`] = `
           "m": Infinity,
           "n": 0,
         },
+        "Operator": {
+          "Type": "default",
+          "Value": {
+            "Type": "literal",
+            "Unwrapped": false,
+            "Value": 1.5,
+          },
+        },
         "Type": [
           {
-            "Operator": {
-              "Type": "default",
-              "Value": {
-                "Type": "literal",
-                "Unwrapped": false,
-                "Value": 1.5,
-              },
-            },
             "Type": {
               "Type": "range",
               "Unwrapped": false,
@@ -2301,6 +2301,68 @@ exports[`parser > can parse operators 1`] = `
         },
         "Type": [
           "float",
+          "null",
+        ],
+      },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "anotherChoice",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Operator": {
+          "Type": "default",
+          "Value": "null",
+        },
+        "Type": [
+          {
+            "Type": {
+              "Type": "range",
+              "Unwrapped": false,
+              "Value": {
+                "Inclusive": false,
+                "Max": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 360,
+                },
+                "Min": {
+                  "Type": "literal",
+                  "Unwrapped": false,
+                  "Value": 0,
+                },
+              },
+            },
+          },
+          "null",
+        ],
+      },
+      {
+        "Comments": [],
+        "HasCut": true,
+        "Name": "yetAnotherChoice",
+        "Occurrence": {
+          "m": Infinity,
+          "n": 0,
+        },
+        "Operator": {
+          "Type": "default",
+          "Value": "null",
+        },
+        "Type": [
+          {
+            "Operator": {
+              "Type": "ge",
+              "Value": {
+                "Type": "literal",
+                "Unwrapped": false,
+                "Value": 1,
+              },
+            },
+            "Type": "float",
+          },
           "null",
         ],
       },


### PR DESCRIPTION
Handling edge cases for operators such as unnamed ranges with a postfix operator (e.g. `? anotherChoice: (0.0...360.0) / null .default null`) and nested operators (e.g., `? yetAnotherChoice: (float .ge 1.0) / null .default null`)